### PR TITLE
Custom page sizes, and a couple of bug fixes

### DIFF
--- a/lib/commandline_parser.rb
+++ b/lib/commandline_parser.rb
@@ -51,7 +51,8 @@ class CommandlineParser
       "b5"          => [516,729],
       "folio"       => [612,936],
       "quarto"      => [610,780],
-      "10x14"       => [720,1008]
+      "10x14"       => [720,1008],
+      "custom:WxH"  => ["INVALID", "INVALID"]
     }
     orientations = {
       'landscape' => NSLandscapeOrientation,
@@ -68,7 +69,7 @@ class CommandlineParser
       opt :hcenter, "Center horizontally", :short => 'c', :default => true
       opt :vcenter, "Center vertically", :default => true
       opt :paginate, 'Enable pagination', :default => true
-      opt :margins, 'Paper margins in points (T R B L) (V H) or (M)', :short => 'm', :default => [0,0,0,0]
+      opt :margins, 'Paper margins in points (T R B L) (V H) or (M)', :short => 'm', :type => :integers
       opt :caching, 'Load from cache if possible', :default => true
       opt :timeout, 'Set timeout to N seconds', :default => 3600.00
       opt :stylesheet_media, 'Set the CSS media value', :default => 'screen' 
@@ -105,6 +106,8 @@ class CommandlineParser
       NSURLRequestUseProtocolCachePolicy : NSURLRequestUseProtocolCachePolicy
     
     opts[:paper] = opts[:paper].downcase
+    paper_sizes[opts[:paper]] = [ $~[1], $~[2] ] if opts[:paper] =~ /custom:(\d+)x(\d+)/
+      
     unless paper_sizes.has_key?(opts[:paper])
       Trollop::die :paper, "unrecognized paper size\nUse one of: " + paper_sizes.keys.join(', ')
       NSApplication.sharedApplication.terminate(nil)
@@ -112,7 +115,7 @@ class CommandlineParser
     dimensions = paper_sizes[opts[:paper]]
     @paperSize = NSMakeSize(dimensions[0], dimensions[1])
     
-    @margins = opts[:margins]
+    @margins = opts[:margins] || [:auto, :auto, :auto, :auto]
     @margins = @margins * 4 if @margins.count == 1
     @margins = [@margins[0], @margins[1]] * 2 if @margins.count == 2
     unless @margins.count == 4

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -135,11 +135,11 @@ class Controller < NSObject
     printInfo.setHorizontallyCentered(p.horizontallyCentered)
     printInfo.setOrientation(p.paperOrientation)
     printInfo.setPaperSize(p.paperSize)
-
-    printInfo.setTopMargin(p.margins[0]) if p.margins[0]
-    printInfo.setRightMargin(p.margins[1]) if p.margins[1]
-    printInfo.setBottomMargin(p.margins[2]) if p.margins[2]
-    printInfo.setLeftMargin(p.margins[3]) if p.margins[3]
+    
+    printInfo.setTopMargin(p.margins[0]) if p.margins[0] != :auto
+    printInfo.setRightMargin(p.margins[1]) if p.margins[1] != :auto
+    printInfo.setBottomMargin(p.margins[2]) if p.margins[2] != :auto
+    printInfo.setLeftMargin(p.margins[3]) if p.margins[3] != :auto
 
     viewToPrint = webView.mainFrame.frameView.documentView
     printOp = NSPrintOperation.printOperationWithView_printInfo(viewToPrint,printInfo)
@@ -155,11 +155,11 @@ class Controller < NSObject
     p = CommandlineParser.instance
     viewToPrint = webView.mainFrame.frameView.documentView
     r = viewToPrint.bounds
-    if p.margins.any?{|x| x > 0} then
-      r.origin.x -= p.margins[1] + p.margins[3]
-      r.origin.y -= p.margins[0] + p.margins[2]
-      r.size.width += (p.margins[1] + p.margins[3]) * 2
-      r.size.height += (p.margins[0] + p.margins[2]) * 2
+    if p.margins.any?{|x| x != :auto } then
+      r.origin.x -= p.margins[1]
+      r.origin.y -= p.margins[0]
+      r.size.width += (p.margins[1] + p.margins[3]) 
+      r.size.height += (p.margins[0] + p.margins[2]) 
     end
 
     log("Create PDF\n")


### PR DESCRIPTION
Thanks for writing this, you've saved me from a lot of hurt. I suspected that PDF generation code would be simple on OS X if someone who knew their way around. I used to, sniff...

I did 3 things:
1) I needed an ability to specify custom pages. I implemented it as a page size custom:WxH
2) I needed 0-width margins. You were using 0 as "do not set margins" flag. I changed it so that :auto means "no margins".
3) Bugfix: margins on singlePagePdf now work. width & height were 2x bigger, x & y were also off.
