### PR TITLE
Changed @margins.count to @margins.length

### DIFF
--- a/lib/commandline_parser.rb
+++ b/lib/commandline_parser.rb
@@ -118,10 +118,10 @@ class CommandlineParser
     @paperSize = NSMakeSize(dimensions[0], dimensions[1])
     
     @margins = opts[:margins] || [:auto, :auto, :auto, :auto]
-    @margins = @margins * 4 if @margins.count == 1
-    @margins = [@margins[0], @margins[1]] * 2 if @margins.count == 2
+    @margins = @margins * 4 if @margins.length == 1
+    @margins = [@margins[0], @margins[1]] * 2 if @margins.length == 2
 
-    unless @margins.count == 4
+    unless @margins.length == 4
       Trollop::die :margins, 'Malformed margins option'
       NSApplication.sharedApplication.terminate(nil)
     end


### PR DESCRIPTION
This fixed an error that was being produced on Mac OSX 10.5:

undefined method 'count' for [:auto, :auto, :auto, :auto]:Array (NoMethodError)

No idea why .count wasn't working, but .length seems to do the trick
