### PR TITLE
fixed issue with --save-delay

### DIFF
--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -36,7 +36,7 @@ class Controller < NSObject
     @saveTimer.invalidate unless @saveTimer.nil?
     @saveTimer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats(
       p.saveDelay, self, :makePDF_, @saveTimer, false)
-    makePDF(nil)
+
   end
 
   def webView_didStartProvisionalLoadForFrame(sender,frame)


### PR DESCRIPTION
There was a stray call in controller.rb, an extra makePDF(nil) that was preventing the  NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats from running.  The entire routine was prematurely exiting.  Now it does a delay for the proper number of --save-delay <seconds>
