### PR TITLE
Small bug fixes in paper size

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 --- 
 :minor: 6
-:patch: 8
+:patch: 9
 :build: 
 :major: 0

--- a/lib/commandline_parser.rb
+++ b/lib/commandline_parser.rb
@@ -35,7 +35,7 @@ class CommandlineParser
 
     paper_sizes = {
       "letter"      => [612,792],
-      "letterSmall" => [612,792],
+      "lettersmall" => [612,792],
       "tabloid"     => [792,1224],
       "ledger"      => [1224,792],
       "legal"       => [612,1008],
@@ -87,6 +87,7 @@ class CommandlineParser
       opt :help, 'Show this message', :short => 'h'
       opt :debug, 'Print debug output', :default => false, :short => 'd'
       banner ""
+      banner "Margins and custom paper sizes are measured in points (72 points = 1 inch.)"
       banner "Further information: http://plessl.github.com/wkpdf"
       banner ""
     end


### PR DESCRIPTION
Fixed issue where "letterSmall" was not recognized as a valid paper
size.  Added text to the help message to clarify how to specify a
custom paper size.
